### PR TITLE
Avoid an exception when dotenv was unable to parse any variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = (cypressConfig, dotEnvConfig) => {
   // load the content of the .env file, then parse each variable to the correct type (string, number, boolean, etc.)
   let envVars = require('dotenv').config(dotEnvConfig)
   const dotenvParseVariables = require('dotenv-parse-variables')
-  envVars = dotenvParseVariables(envVars.parsed)
+  envVars = dotenvParseVariables(envVars.parsed || {})
 
   let enhancedConfig = clonedeep(cypressConfig)
   enhancedConfig.env = enhancedConfig.env || {}


### PR DESCRIPTION
If, for instance, there isn't a .env file to load, dotenv might return null or undefined.