### PR TITLE
Adding a possibility to return all env variables without prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Cypress plugin that enables compatability with [dotenv](https://www.npmjs.com/pa
 [![Test Coverage](https://api.codeclimate.com/v1/badges/0d189dae8e924ada81ad/test_coverage)](https://codeclimate.com/github/morficus/cypress-dotenv/test_coverage)
 
 ## What does this thing do?
-It will load any [`CYPRESS_*` environment variables](https://docs.cypress.io/guides/guides/environment-variables.html#Option-2-cypress-env-json) defined in your `.env` file so you can access them via `Cypress.env()` from within your tests as you would expect.  
+It will load any [`environment variables](https://docs.cypress.io/guides/guides/environment-variables.html#Option-2-cypress-env-json) defined in your `.env` file so you can access them via `Cypress.env()` from within your tests as you would expect.  
 
 Any [Cypress config options](https://docs.cypress.io/guides/references/configuration.html) definedin your .env will also be applied and take precesende over what is in your `cypress.json` file. See the [Cypress docs for detials on this](https://docs.cypress.io/guides/references/configuration.html#Environment-Variables)
 
@@ -42,4 +42,8 @@ module.exports = (on, config) => {
 ```
 
 ## Options
-This plugin takes two paramaters. The first parameter (which is mandatory) is the Cypress config object and the other is an optional [dotenv](https://www.npmjs.com/package/dotenv#config) config object.
+This plugin takes three paramaters. The first parameter (which is mandatory) is the Cypress config object. 
+
+The second is an optional [dotenv](https://www.npmjs.com/package/dotenv#config) config object.
+
+The third is an optional [all] parameter, which is set to false by default. If set to true, it returns all available environmental variables, not limited to those prefixed with CYPRESS_.

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ This plugin takes three paramaters. The first parameter (which is mandatory) is 
 
 The second is an optional [dotenv](https://www.npmjs.com/package/dotenv#config) config object.
 
-The third is an optional [all] parameter, which is set to false by default. If set to true, it returns all available environmental variables, not limited to those prefixed with CYPRESS_.
+The third is an optional [all] boolean parameter, which is set to false by default. If set to true, it returns all available environmental variables, not limited to those prefixed with CYPRESS_.

--- a/index.js
+++ b/index.js
@@ -6,9 +6,10 @@ const clonedeep = require('lodash.clonedeep')
  *
  * @param {object} cypressConfig - The cypress config object
  * @param {object} dotEnvConfig - (optional) The dotenv config object, ref: https://www.npmjs.com/package/dotenv#config
+ * @param {string} all - (optional) Whether to return all env variables. If set to false (default), only env variables prefixed with CYPRESS_ are returned.
  * @returns {object} The cypress config with an augmented `env` property
  */
-module.exports = (cypressConfig, dotEnvConfig) => {
+module.exports = (cypressConfig, dotEnvConfig, all = false) => {
   // load the content of the .env file, then parse each variable to the correct type (string, number, boolean, etc.)
   let envVars = require('dotenv').config(dotEnvConfig)
   const dotenvParseVariables = require('dotenv-parse-variables')
@@ -18,15 +19,15 @@ module.exports = (cypressConfig, dotEnvConfig) => {
   enhancedConfig.env = enhancedConfig.env || {}
 
   // get the name of all env vars that relate to cypress
-  const cypressEnvVarKeys = Object.keys(envVars).filter(envName => envName.startsWith('CYPRESS_'))
+  const cypressEnvVarKeys = all
+    ? Object.keys(envVars).filter(envName => envName)
+    : Object.keys(envVars).filter(envName => envName.startsWith('CYPRESS_'))
 
   cypressEnvVarKeys.forEach(originalName => {
     const cleanName = originalName.replace('CYPRESS_', '')
     const camelCaseName = camelcase(cleanName)
     enhancedConfig.env[cleanName] = envVars[originalName]
 
-    // only overwrite Cypress config options that are infact valid options,
-    // but ignore the `env` property... otherwise we will be in a world of pain
     if (enhancedConfig.hasOwnProperty(camelCaseName) && camelCaseName !== 'env') {
       enhancedConfig[camelCaseName] = envVars[originalName]
     }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const clonedeep = require('lodash.clonedeep')
  *
  * @param {object} cypressConfig - The cypress config object
  * @param {object} dotEnvConfig - (optional) The dotenv config object, ref: https://www.npmjs.com/package/dotenv#config
- * @param {string} all - (optional) Whether to return all env variables. If set to false (default), only env variables prefixed with CYPRESS_ are returned.
+ * @param {boolean} all - (optional) Whether to return all env variables. If set to false (default), only env variables prefixed with CYPRESS_ are returned.
  * @returns {object} The cypress config with an augmented `env` property
  */
 module.exports = (cypressConfig, dotEnvConfig, all = false) => {
@@ -20,7 +20,7 @@ module.exports = (cypressConfig, dotEnvConfig, all = false) => {
 
   // get the name of all env vars that relate to cypress
   const cypressEnvVarKeys = all
-    ? Object.keys(envVars).filter(envName => envName)
+    ? Object.keys(envVars)
     : Object.keys(envVars).filter(envName => envName.startsWith('CYPRESS_'))
 
   cypressEnvVarKeys.forEach(originalName => {

--- a/index.spec.js
+++ b/index.spec.js
@@ -72,4 +72,20 @@ describe('Cypress dotenv plugin', () => {
     const enhancedConfig = plugin(cypressConfigExample)
     expect(typeof enhancedConfig.env).toEqual('object')
   })
+
+  describe('Optional all argument', () => {
+    it('Should return all available env vars', () => {
+      const dotenvConfig = { path: './.env' }
+      const enhancedConfig = plugin(cypressConfigExample, dotenvConfig, true)
+
+      expect(enhancedConfig.env).toEqual({
+        BASE_URL: 'http://google.com',
+        ENV: 'testing',
+        I_AM_BOOLEAN: true,
+        I_AM_NUMBER: 100,
+        NON_TEST_VAR: 'goodbye',
+        TEST_VAR: 'hello'
+      })
+    })
+  })
 })


### PR DESCRIPTION
Hello @morficus. Thanks for this great project. Submitting a PR for the plugin to see all env variables, not just those prefixed with CYPRESS_. Also adding a test for that functionality.