### PR TITLE
ensure existing cypress envars are honored

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,10 +41,14 @@ module.exports = (cypressConfig, dotEnvConfig, all = false) => {
     const pattern = new RegExp(`^${cypressPrefix}`, 'g')
     const cleanName = originalName.replace(pattern, '')
     const camelCaseName = camelcase(cleanName)
-    enhancedConfig.env[cleanName] = envVars[originalName]
+    const parsedEnvar = envVars[originalName]
+    const processEnvVar =  process.env[originalName]
+    const envVar = typeof parsedEnvar === 'string' ? processEnvVar : parsedEnvar
+    
+    enhancedConfig.env[cleanName] = envVar
 
     if (enhancedConfig.hasOwnProperty(camelCaseName) && camelCaseName !== 'env') {
-      enhancedConfig[camelCaseName] = envVars[originalName]
+      enhancedConfig[camelCaseName] = envVar
     }
   })
 

--- a/index.spec.js
+++ b/index.spec.js
@@ -52,6 +52,15 @@ describe('Cypress dotenv plugin', () => {
     expect(enhancedConfig.env.SOME_OTHER_ENV_VAR).toEqual('hey there')
   })
 
+  it('Should not alter existing CYPRESS_ environment variables', () => {
+    process.env['CYPRESS_TEST_VAR'] = 'existing';
+
+    plugin(cypressConfigExample)
+    expect(process.env.CYPRESS_TEST_VAR).toBeDefined()
+    expect(process.env.CYPRESS_TEST_VAR).not.toEqual('hello')
+    expect(process.env.CYPRESS_TEST_VAR).toEqual('existing')
+  })
+
   it('Should update any standard Cypress config keys, even if the .env key is in SNAKE_CASE', () => {
     const enhancedConfig = plugin(cypressConfigExample)
 


### PR DESCRIPTION
Fixes: https://github.com/morficus/cypress-dotenv/issues/18

Issue is that `dotenv` will not add existing environment variables to the process, but will return them as parsed. This library would then override any existing CYPRESS_ variables from the `.env` file as it uses the parsed values always.